### PR TITLE
update homebrew instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Setup
 
-* ```brew install swi-prolog```
+* ```brew install Caskroom/cask/swi-prolog```
 
 # Run Tests
 


### PR DESCRIPTION
My homebrew did not have swi-prolog, so I had to install it through casks. Was this true for you too, Mark?
